### PR TITLE
upgrade jsoup version to 1.13.1

### DIFF
--- a/OGParser/build.gradle
+++ b/OGParser/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
     // OpenGraph
-    implementation 'org.jsoup:jsoup:1.10.3'
+    implementation 'org.jsoup:jsoup:1.13.1'
 
     // Preference AndroidX
     def preference_version = "1.1.1"


### PR DESCRIPTION
Issue: Was getting crash while parsing url on release builds (with minifyEnabled = true)
 upgrading the version solved the issue.